### PR TITLE
chore: bump connector-runtime to 0.22.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
     <!-- connector SDK version -->
-    <version.connector-core>0.11.2</version.connector-core>
+    <version.connector-core>0.22.0</version.connector-core>
     <version.connector-runtime>0.22.0</version.connector-runtime>
 
     <!-- external libraries -->

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
     <!-- connector SDK version -->
     <version.connector-core>0.11.2</version.connector-core>
-    <version.connector-runtime>0.21.4</version.connector-runtime>
+    <version.connector-runtime>0.22.0</version.connector-runtime>
 
     <!-- external libraries -->
     <version.assertj>3.24.2</version.assertj>

--- a/src/main/java/io/camunda/connector/inbound/MyConnectorProperties.java
+++ b/src/main/java/io/camunda/connector/inbound/MyConnectorProperties.java
@@ -1,8 +1,8 @@
 package io.camunda.connector.inbound;
 
-import javax.validation.constraints.Max;
-import javax.validation.constraints.Min;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 
 /**
  * Configuration properties for inbound Connector


### PR DESCRIPTION
## Description

New version was released, so have to adjust version.

## Related issues

https://github.com/camunda/team-connectors/issues/475 

closes #

