### PR TITLE
chore(template): update to connector & camunda 8.9

### DIFF
--- a/element-templates/template-connector-message-start-event.json
+++ b/element-templates/template-connector-message-start-event.json
@@ -132,6 +132,18 @@
     },
     "type" : "String"
   }, {
+    "id" : "messageIdExpression",
+    "label" : "Message ID expression",
+    "description" : "Expression to extract unique identifier of a message",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "correlation",
+    "binding" : {
+      "name" : "messageIdExpression",
+      "type" : "zeebe:property"
+    },
+    "type" : "String"
+  }, {
     "id" : "messageTtl",
     "label" : "Message TTL",
     "description" : "Time-to-live for the message in the broker (ISO-8601 duration)",
@@ -147,18 +159,6 @@
     "group" : "correlation",
     "binding" : {
       "name" : "messageTtl",
-      "type" : "zeebe:property"
-    },
-    "type" : "String"
-  }, {
-    "id" : "messageIdExpression",
-    "label" : "Message ID expression",
-    "description" : "Expression to extract unique identifier of a message",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "correlation",
-    "binding" : {
-      "name" : "messageIdExpression",
       "type" : "zeebe:property"
     },
     "type" : "String"

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <version.connectors>8.7.2</version.connectors>
+        <version.connectors>8.9.0</version.connectors>
         <version.assertj>3.27.3</version.assertj>
         <version.junit-jupiter>5.13.0</version.junit-jupiter>
         <version.mockito>5.18.0</version.mockito>

--- a/src/main/java/io/camunda/connector/inbound/MyConnectorProperties.java
+++ b/src/main/java/io/camunda/connector/inbound/MyConnectorProperties.java
@@ -1,6 +1,7 @@
 package io.camunda.connector.inbound;
 
 import io.camunda.connector.generator.dsl.Property;
+import io.camunda.connector.generator.java.annotation.FeelMode;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -19,13 +20,13 @@ public record MyConnectorProperties(
             label = "Sender",
             group = "properties",
             binding = @TemplateProperty.PropertyBinding(name = "sender"),
-            feel = Property.FeelMode.optional)
+            feel = FeelMode.optional)
     String sender,
     @TemplateProperty(
             id = "messagesPerMinute",
             label = "Message per minute",
             group = "properties",
             binding = @TemplateProperty.PropertyBinding(name = "messagesPerMinute"),
-            feel = Property.FeelMode.optional)
+            feel = FeelMode.optional)
     @Max(10) @Min(1) int messagesPerMinute
 ) {}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,6 +1,6 @@
 server.port=9898
 camunda.client.zeebe.grpc-address=http://localhost:26500
-camunda.client.zeebe.rest-address=http://localhost:8088
+camunda.client.zeebe.rest-address=http://localhost:8080
 
 # comment out for docker-compose-core.yml
 operate.client.profile=oidc


### PR DESCRIPTION
This pull request includes several updates across the project, focusing on dependency upgrades, template corrections, code cleanup, and configuration adjustments. The most notable changes are the upgrade of the connectors library version, correction of a duplicated property in an element template, simplification of annotation usage in Java code, and an update to a test configuration property.

**Dependency and Template Updates:**

* Upgraded the connectors dependency version in `pom.xml` from `8.7.2` to `8.9.0`, ensuring the project uses the latest features and fixes.
* Fixed a duplication issue in `element-templates/template-connector-message-start-event.json` by removing a redundant `messageIdExpression` property and ensuring it is defined only once. [[1]](diffhunk://#diff-69b824b4234546e3ebae12415939df641be48a415f7598b0ae31ca23a8e5c816R134-R145) [[2]](diffhunk://#diff-69b824b4234546e3ebae12415939df641be48a415f7598b0ae31ca23a8e5c816L153-L164)

**Code Cleanup:**

* Updated imports in `MyConnectorProperties.java` to use `FeelMode` directly from the annotation package, instead of referencing it through `Property`, simplifying the annotation usage. [[1]](diffhunk://#diff-372fce52c6b197a2e8ed7087337a30fcf0c8d52caa379e449c7c4b578847a840R4) [[2]](diffhunk://#diff-372fce52c6b197a2e8ed7087337a30fcf0c8d52caa379e449c7c4b578847a840L22-R30)

**Configuration Changes:**

* Changed the Zeebe REST address in the test `application.properties` from port `8088` to `8080` to match the expected environment.

