### PR TITLE
chore(template): update to connector & camunda 8.9

### DIFF
--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -10,7 +10,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.2.5</version>
+        <version>3.5.5</version>
       </plugin>
       <plugin>
         <artifactId>maven-shade-plugin</artifactId>
@@ -83,29 +83,33 @@
     <dependency>
       <groupId>io.camunda.connector</groupId>
       <artifactId>connector-core</artifactId>
-      <version>8.8.2</version>
+      <version>8.9.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.camunda.connector</groupId>
       <artifactId>connector-test</artifactId>
-      <version>8.8.2</version>
+      <version>8.9.0</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
-          <artifactId>connector-validation</artifactId>
-          <groupId>io.camunda.connector</groupId>
+          <artifactId>junit-jupiter-api</artifactId>
+          <groupId>org.junit.jupiter</groupId>
         </exclusion>
       </exclusions>
     </dependency>
     <dependency>
       <groupId>io.camunda.connector</groupId>
       <artifactId>connector-runtime-test</artifactId>
-      <version>8.8.2</version>
+      <version>8.9.0</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
           <artifactId>connector-runtime-core</artifactId>
+          <groupId>io.camunda.connector</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>jackson-datatype-feel</artifactId>
           <groupId>io.camunda.connector</groupId>
         </exclusion>
         <exclusion>
@@ -117,7 +121,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>5.20.0</version>
+      <version>5.23.0</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -137,7 +141,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-junit-jupiter</artifactId>
-      <version>5.20.0</version>
+      <version>5.23.0</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -149,7 +153,7 @@
     <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
-      <version>4.2.0</version>
+      <version>4.3.0</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -161,11 +165,19 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-process-test-spring</artifactId>
-      <version>8.8.2</version>
+      <version>8.9.0</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
           <artifactId>camunda-process-test-java</artifactId>
+          <groupId>io.camunda</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>camunda-process-test-json-test-cases</artifactId>
+          <groupId>io.camunda</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>camunda-process-test-langchain4j</artifactId>
           <groupId>io.camunda</groupId>
         </exclusion>
         <exclusion>
@@ -229,7 +241,7 @@
     <dependency>
       <groupId>io.camunda.connector</groupId>
       <artifactId>spring-boot-starter-camunda-connectors</artifactId>
-      <version>8.8.2</version>
+      <version>8.9.0</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -237,12 +249,52 @@
           <groupId>io.camunda.connector</groupId>
         </exclusion>
         <exclusion>
-          <artifactId>spring-boot-starter-web</artifactId>
+          <artifactId>http-client</artifactId>
+          <groupId>io.camunda.connector</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>spring-boot-starter-webmvc</artifactId>
           <groupId>org.springframework.boot</groupId>
         </exclusion>
         <exclusion>
           <artifactId>spring-boot-starter-actuator</artifactId>
           <groupId>org.springframework.boot</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>spring-boot-health</artifactId>
+          <groupId>org.springframework.boot</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>spring-boot-micrometer-metrics</artifactId>
+          <groupId>org.springframework.boot</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>spring-boot-starter-cache</artifactId>
+          <groupId>org.springframework.boot</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>jakarta.annotation-api</artifactId>
+          <groupId>jakarta.annotation</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>micrometer-core</artifactId>
+          <groupId>io.micrometer</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>spring-web</artifactId>
+          <groupId>org.springframework</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>connector-validation</artifactId>
+          <groupId>io.camunda.connector</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>connector-runtime-core</artifactId>
+          <groupId>io.camunda.connector</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>jackson-datatype-feel</artifactId>
+          <groupId>io.camunda.connector</groupId>
         </exclusion>
         <exclusion>
           <artifactId>camunda-spring-boot-starter</artifactId>
@@ -257,8 +309,20 @@
           <groupId>org.springframework</groupId>
         </exclusion>
         <exclusion>
-          <artifactId>connector-validation</artifactId>
-          <groupId>io.camunda.connector</groupId>
+          <artifactId>spring-beans</artifactId>
+          <groupId>org.springframework</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>spring-context</artifactId>
+          <groupId>org.springframework</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>spring-boot</artifactId>
+          <groupId>org.springframework.boot</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>spring-boot-autoconfigure</artifactId>
+          <groupId>org.springframework.boot</groupId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -266,15 +330,15 @@
   <properties>
     <maven.compiler.release>21</maven.compiler.release>
     <version.assertj>3.27.6</version.assertj>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <version.connectors>8.8.2</version.connectors>
-    <version.camunda>8.8.2</version.camunda>
     <java.version>21</java.version>
-    <version.awaitility>4.2.0</version.awaitility>
+    <version.awaitility>4.3.0</version.awaitility>
     <maven.compiler.source>21</maven.compiler.source>
-    <version.mockito>5.20.0</version.mockito>
+    <version.mockito>5.23.0</version.mockito>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <maven.compiler.target>21</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <version.junit-jupiter>6.0.0</version.junit-jupiter>
+    <version.connectors>8.9.0</version.connectors>
+    <version.camunda>8.9.0</version.camunda>
   </properties>
 </project>

--- a/element-templates/template-connector-message-start-event.json
+++ b/element-templates/template-connector-message-start-event.json
@@ -132,6 +132,18 @@
     },
     "type" : "String"
   }, {
+    "id" : "messageIdExpression",
+    "label" : "Message ID expression",
+    "description" : "Expression to extract unique identifier of a message",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "correlation",
+    "binding" : {
+      "name" : "messageIdExpression",
+      "type" : "zeebe:property"
+    },
+    "type" : "String"
+  }, {
     "id" : "messageTtl",
     "label" : "Message TTL",
     "description" : "Time-to-live for the message in the broker (ISO-8601 duration)",
@@ -147,18 +159,6 @@
     "group" : "correlation",
     "binding" : {
       "name" : "messageTtl",
-      "type" : "zeebe:property"
-    },
-    "type" : "String"
-  }, {
-    "id" : "messageIdExpression",
-    "label" : "Message ID expression",
-    "description" : "Expression to extract unique identifier of a message",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "correlation",
-    "binding" : {
-      "name" : "messageIdExpression",
       "type" : "zeebe:property"
     },
     "type" : "String"

--- a/pom.xml
+++ b/pom.xml
@@ -13,8 +13,8 @@
         <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <version.connectors>8.8.8</version.connectors>
-        <version.camunda>8.8.21</version.camunda>
+        <version.connectors>8.9.0</version.connectors>
+        <version.camunda>8.9.0</version.camunda>
         <version.assertj>3.27.6</version.assertj>
         <version.mockito>5.23.0</version.mockito>
         <version.junit-jupiter>6.0.0</version.junit-jupiter>

--- a/src/main/java/io/camunda/connector/inbound/MyConnectorProperties.java
+++ b/src/main/java/io/camunda/connector/inbound/MyConnectorProperties.java
@@ -1,6 +1,7 @@
 package io.camunda.connector.inbound;
 
 import io.camunda.connector.generator.dsl.Property;
+import io.camunda.connector.generator.java.annotation.FeelMode;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -19,13 +20,13 @@ public record MyConnectorProperties(
             label = "Sender",
             group = "properties",
             binding = @TemplateProperty.PropertyBinding(name = "sender"),
-            feel = Property.FeelMode.optional)
+            feel = FeelMode.optional)
     String sender,
     @TemplateProperty(
             id = "messagesPerMinute",
             label = "Message per minute",
             group = "properties",
             binding = @TemplateProperty.PropertyBinding(name = "messagesPerMinute"),
-            feel = Property.FeelMode.optional)
+            feel = FeelMode.optional)
     @Max(10) @Min(1) int messagesPerMinute
 ) {}

--- a/src/test/java/io/camunda/connector/inbound/integration/TestConnectorRuntimeApplication.java
+++ b/src/test/java/io/camunda/connector/inbound/integration/TestConnectorRuntimeApplication.java
@@ -7,12 +7,11 @@ import io.camunda.connector.runtime.core.document.store.InMemoryDocumentStore;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchRestClientAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
-@SpringBootApplication(exclude = {ElasticsearchRestClientAutoConfiguration.class})
+@SpringBootApplication
 @ImportAutoConfiguration({
   io.camunda.connector.runtime.InboundConnectorsAutoConfiguration.class,
   io.camunda.connector.runtime.OutboundConnectorsAutoConfiguration.class,
@@ -28,7 +27,7 @@ public class TestConnectorRuntimeApplication {
 
   @Bean
   @Primary
-  public DocumentFactory documentFactory() {
+  public DocumentFactory testDocumentFactory() {
     return new DocumentFactoryImpl(InMemoryDocumentStore.INSTANCE);
   }
 }

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,6 +1,6 @@
 server.port=9898
 camunda.client.grpc-address=http://localhost:26500
-camunda.client.rest-address=http://localhost:8088
+camunda.client.rest-address=http://localhost:8080
 camunda.connector.secretprovider.environment.enabled=false
 
 # comment out for docker-compose-core.yml


### PR DESCRIPTION
This pull request updates dependencies, refines test and template configurations, and makes minor code improvements to align with the latest library versions and best practices.

**Dependency Upgrades and Exclusions:**

* Updated multiple dependencies to the latest versions, including `io.camunda.connector`, `org.mockito`, `org.awaitility`, and related properties in both `pom.xml` and `dependency-reduced-pom.xml` to ensure compatibility and access to new features. [[1]](diffhunk://#diff-7182001772a851ff92a09525a7b6d383ea0315d75612d43e3272a78adb3058c1L86-R114) [[2]](diffhunk://#diff-7182001772a851ff92a09525a7b6d383ea0315d75612d43e3272a78adb3058c1L120-R124) [[3]](diffhunk://#diff-7182001772a851ff92a09525a7b6d383ea0315d75612d43e3272a78adb3058c1L140-R144) [[4]](diffhunk://#diff-7182001772a851ff92a09525a7b6d383ea0315d75612d43e3272a78adb3058c1L152-R156) [[5]](diffhunk://#diff-7182001772a851ff92a09525a7b6d383ea0315d75612d43e3272a78adb3058c1L164-R182) [[6]](diffhunk://#diff-7182001772a851ff92a09525a7b6d383ea0315d75612d43e3272a78adb3058c1L232-R298) [[7]](diffhunk://#diff-7182001772a851ff92a09525a7b6d383ea0315d75612d43e3272a78adb3058c1L260-R342) [[8]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L16-R17)
* Added and adjusted exclusions for unnecessary transitive dependencies in test and runtime scopes, reducing potential conflicts and slimming the build. [[1]](diffhunk://#diff-7182001772a851ff92a09525a7b6d383ea0315d75612d43e3272a78adb3058c1L86-R114) [[2]](diffhunk://#diff-7182001772a851ff92a09525a7b6d383ea0315d75612d43e3272a78adb3058c1L164-R182) [[3]](diffhunk://#diff-7182001772a851ff92a09525a7b6d383ea0315d75612d43e3272a78adb3058c1L232-R298) [[4]](diffhunk://#diff-7182001772a851ff92a09525a7b6d383ea0315d75612d43e3272a78adb3058c1L260-R342)

**Template and Property Annotation Adjustments:**

* Corrected the usage of the `FeelMode` annotation in `MyConnectorProperties` for improved annotation consistency. [[1]](diffhunk://#diff-372fce52c6b197a2e8ed7087337a30fcf0c8d52caa379e449c7c4b578847a840R4) [[2]](diffhunk://#diff-372fce52c6b197a2e8ed7087337a30fcf0c8d52caa379e449c7c4b578847a840L22-R30)
* Updated the message start event template by moving the `messageIdExpression` property to a different position, ensuring the template structure is correct. [[1]](diffhunk://#diff-69b824b4234546e3ebae12415939df641be48a415f7598b0ae31ca23a8e5c816R134-R145) [[2]](diffhunk://#diff-69b824b4234546e3ebae12415939df641be48a415f7598b0ae31ca23a8e5c816L153-L164)

**Test Configuration Improvements:**

* Changed the test application's REST address to the default port (`8080`) for better local development compatibility.
* Removed the exclusion of `ElasticsearchRestClientAutoConfiguration` from the test application and renamed a bean for clarity. [[1]](diffhunk://#diff-0b809e06230d036f8435e9f7697bc643785c5942141a2fa763efd67518078449L10-R14) [[2]](diffhunk://#diff-0b809e06230d036f8435e9f7697bc643785c5942141a2fa763efd67518078449L31-R30)

**Build Plugin Update:**

* Upgraded the `maven-surefire-plugin` to version `3.5.5` for improved test execution and compatibility with newer dependency versions.